### PR TITLE
Fix regex escaping in pyproject.toml exclude_lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,8 +166,8 @@ exclude_lines = [
     "raise NotImplementedError",
     "if 0:",
     "if __name__ == .__main__.:",
-    "class .*\bProtocol\):",
-    "@(abc\.)?abstractmethod",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
 ]
 
 [tool.bandit]


### PR DESCRIPTION
## Summary
- Corrects regex patterns in `pyproject.toml` for excluding lines during linting or analysis
- Fixes improper escaping of backslashes in regex strings

## Changes

### Configuration Update
- Updated `exclude_lines` in `pyproject.toml`:
  - Changed `class .*\bProtocol\):` to properly escape backslashes
  - Changed `@(abc\.)?abstractmethod` to properly escape backslashes

## Test plan
- Verified that the updated regex patterns are correctly recognized by the tooling
- Ensured no linting or analysis errors occur due to these patterns after the fix

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c016e942-ac78-4867-a3c4-5c8975f1ad81